### PR TITLE
fix: performance issue when dealing with models with a lot of objects rendering over and over again

### DIFF
--- a/bpycv/material_utils.py
+++ b/bpycv/material_utils.py
@@ -32,16 +32,18 @@ class set_inst_material(StatuRecover):
             inst_id = obj.get("inst_id", 0)  # default inst_id is 0
             color = tuple(encode_inst_id.id_to_rgb(inst_id)) + (1,)
 
-            material_name = "auto.inst_material." + obj.name
-            material = bpy.data.materials.new(material_name)
-            material["is_auto"] = True
-            material.use_nodes = True
-            material.node_tree.nodes.clear()
-            with activate_node_tree(material.node_tree):
-                Node("ShaderNodeOutputMaterial").Surface = Node(
-                    "ShaderNodeEmission", Color=color
-                ).Emission
-
+            material_name = f"auto.inst_material.{inst_id}"
+            if bpy.data.materials.get(material_name) is None:
+                material = bpy.data.materials.new(material_name)
+                material["is_auto"] = True
+                material.use_nodes = True
+                material.node_tree.nodes.clear()
+                material.name = material_name
+                with activate_node_tree(material.node_tree):
+                    Node("ShaderNodeOutputMaterial").Surface = Node(
+                        "ShaderNodeEmission", Color=color
+                    ).Emission
+            material = bpy.data.materials[material_name]
             self.replace_collection(obj.data.materials, [material])
 
 


### PR DESCRIPTION
In our project, we have models with about 500 objects but much fewer segmentation instances, and when calculating segmentations repeatedly, we had a very annoying performance problem. Each render iteration gets a bit slower kinda linearly.

After some investigation, we discovered that when this library kicks in it creates one material for each object but every time a render is requested it creates another material instead of reusing the one already there.

This pull request changes this behavior by creating one material per _inst_id_ instead of per object and check if the material is already created so it will not be created again reusing that material and avoiding the slowdown.